### PR TITLE
Fix hardcoded path in create-app-icon.sh script

### DIFF
--- a/create-app-icon.sh
+++ b/create-app-icon.sh
@@ -3,7 +3,9 @@
 # Create a simple app icon using built-in tools
 # This creates a basic icon with "LL" text
 
-ICON_DIR="/Users/bernard/src/lacylights/lacylights/LacyLights.app/Contents/Resources"
+# Get the directory where this script is located and construct the app icon path
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ICON_DIR="$SCRIPT_DIR/LacyLights.app/Contents/Resources"
 TEMP_DIR="/tmp/lacylights_icon"
 
 mkdir -p "$ICON_DIR" "$TEMP_DIR"


### PR DESCRIPTION
## Summary
- Replace hardcoded absolute path with dynamic path calculation
- Script now determines its directory using `${BASH_SOURCE[0]}`
- Makes the script portable across different environments

## Changes
The script previously had a hardcoded path `/Users/bernard/src/lacylights/lacylights/LacyLights.app/Contents/Resources` which would only work on one specific machine. 

Now it calculates the path relative to the script's location:
```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
ICON_DIR="$SCRIPT_DIR/LacyLights.app/Contents/Resources"
```

This makes the script work regardless of where the repository is cloned.

## Test plan
- [ ] Run the script from different directories
- [ ] Verify the icon is created in the correct location
- [ ] Confirm no hardcoded paths remain

🤖 Generated with [Claude Code](https://claude.ai/code)